### PR TITLE
Fix SpurtFarmer zone drift

### DIFF
--- a/IC_SpurtFarmer_Extra/IC_SpurtFarmer_Component.ahk
+++ b/IC_SpurtFarmer_Extra/IC_SpurtFarmer_Component.ahk
@@ -72,7 +72,7 @@ class SpurtFarm {
         loop {
             num := ActiveEffectKeySharedFunctions.Spurt.WaspirationHandler.ReadSpurtWasps()
             GuiControl, ICScriptHub:, SpurtFarm_Wasps, % "Current Wasps: " . num
-            if (num >= 15) {
+            if (num >= 15 && g_SF.Memory.ReadTransitioning() == 0) {
                 input := toggle = 1 ? ( "{Left}", toggle := 0) : ( "{Right}", toggle := 1)
                 g_SF.DirectedInput(,,input)
             }


### PR DESCRIPTION
`MemRead loop` runs multiple times during transition, but `num` remains `15` until the next zone loads
-> `toggle` can get out of sync with the desired direction
-> not toggling during transition should fix zone drift