### PR TITLE
Remove Omin's Contractual Obligations dependency, just use all ults when off cooldown

### DIFF
--- a/IC_BetterAzaka_Extra/Addon.json
+++ b/IC_BetterAzaka_Extra/Addon.json
@@ -1,9 +1,9 @@
 {
     "Name": "BetterAzaka",
-    "Version": "v0.0.1",
+    "Version": "v0.0.2",
     "Includes": "IC_BetterAzaka_Component.ahk",
     "Author": "Ismo/Pneumatus",
     "Url": "https://github.com/Pneumatus/IC-Addons/tree/main/IC_BetterAzaka_Extra",
-    "Info": "This AddOn will spam Azaka and other champion's ults at a set Omin number of contracts fulfilled value.",
+    "Info": "This AddOn will spam Azaka and other champions' ultimates when all of them are off cooldown.",
     "Dependencies": {}
 }


### PR DESCRIPTION
- Removed all Contractual Obligations uses / mentions, 
- changed readUltimateCooldownByItem(value) from local to g_SF.Memory (SharedFunctions) one, 
- commented areAllUltsOnCooldown() function as we don't need it right now. 

Works fine for me with Freely/Egbert Q/W switching, haven't tested other usecases myself.